### PR TITLE
Feature request: One terminal command to run both client and server #32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 tmp/
 *.tmp
+node_modules
+package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -34,19 +34,23 @@ dataSourceName = root:123@tcp(localhost:3306)/
 
 Casbin-dashboard uses XORM to connect to DB, so all DBs supported by XORM can also be used.
 
-- Run backend (in port 8000):
+- Run backend (in port 8000) and frontend (in the same machine's port 3030):
 
 ```
-go run main.go
+npm install
+cd web
+npm install
+cd ..
+npm run dev
  ```
-
-- Run frontend (in the same machine's port 3030):
+<!-- go run main.go -->
+<!-- - Run frontend (in the same machine's port 3030):
 
 ```
 cd web
 npm install
 npm start
-```
+``` -->
 
 - Open browser:
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "concurrently": "^5.1.0"
+  },
+  "scripts": {
+    "dev": "concurrently \"go run main.go\" \"cd web && npm run start\""
+  }
+}


### PR DESCRIPTION
#32 Fixes

Added a dependency concurrently in package.json in the root directory which can be installed using `npm install` in the root directory. Updated the README and .gitignore accordingly.

# Actual Behaviour
Currently we need to run 
```
go run main.go
```
 in one terminal and 
```
cd web
npm start
``` 
in another.

# Expected Behaviour
One line code `npm run dev` to run both concurrently on the same terminal. This saves time to open two terminals and check for errors separately and now it can be done in one run.