### PR TITLE
Updated the deprecated componentWillMount

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -26,7 +26,7 @@ class App extends React.Component {
     return location.pathname;
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const path = this.getUrlPath();
     if (path.includes('model')) {
       this.setState({ selectedMenuKey: 2 });


### PR DESCRIPTION
### Description : Updated with componentDidMount
Instead of componentWillMount, use a constructor for the stuff that doesn't produce side-effects, and use componentDidMount for the stuff that does.

Updated componentWillMount which is deprecated in the following react version


### Please ensure Checkmark the following :

- [x] - Tested Localy
- [x] - Checked in IE11 and Firefox
- [x] - Checked in mobile
- [x] - Backend work
- [x] - Frontend work
- [x] - Bug Fixes
- [x] - Enhancements
