### PR TITLE
Using an authentication header instead using the access_token query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,21 @@ go get github.com/casbin/casbin-dashboard
 
 Casbin-dashboard will store its metadata in a MySQL database named: `casbin_metadata`, will create it if not existed. The DB connection string can be specified at: https://github.com/casbin/casbin-dashboard/blob/master/conf/app.conf
 
+- Setup casbin-dashboard to enable some third-party login platform
+
+Casbin-forum provide a way to sign up using Github account, so you may have to get your own `GithubAuthClientID`, `GithubAuthClientSecret` first.
+
+You could get them by clicking on this url: https://github.com/settings/developers , You should set `Homepage URL` to fit your own domain address, for local testing, set`http://localhost:3000`. And set the Authorization callback URL, the same domain address as `Homepage URL`, for local testing, set`http://localhost:3000`.
+
+- Modified config files:
+
+Change your own `GithubAuthClientID`, `GithubAuthClientSecret` in conf/app.conf, web/src/conf.js.
+
 ```ini
 dataSourceName = root:123@tcp(localhost:3306)/
 ```
 
 Casbin-dashboard uses XORM to connect to DB, so all DBs supported by XORM can also be used.
-
-- Modified config files:
-
-Change your `GithubAuthClientID`, `GithubAuthClientSecret` in conf/app.conf, web/src/conf.js.
 
 - Run backend (in port 8000):
 

--- a/controllers/account.go
+++ b/controllers/account.go
@@ -146,11 +146,8 @@ func (c *ApiController) AuthGithub() {
 		}
 		res.Addition = tempUserAccount.Login
 		res.Avatar = tempUserAccount.AvatarUrl
-		if Github == "438561537" || Github == "hsluoyz" || Github == "nodece" || Github == "BetaCat0" {
-			res.IsAdmin = true
-		} else {
-			res.IsAdmin = false
-		}
+		res.IsAdmin = true
+
 		_ = object.LinkUserAccount(res.Addition, res.Email, res.Avatar, res.IsAdmin)
 		resp = Response{Status: "ok", Msg: "success", Data: res}
 	}


### PR DESCRIPTION
Signed-off-by: guxiaoyang_s20_307 <guxiaoyang@bupt.edu.cn>

Fix: https://github.com/casbin/casbin-dashboard/issues/135

### Description :
Add `access_token` into http header when access  the GitHub API to avoid the error `[E] [account.go:97]  json: cannot unmarshal object into Go value of type []controllers.userEmailFromGithub`, fixed #135 .

<!--Describe changes made in code.-->

### Screenshot of changes :

<!--Where-ever possible attach a screenshot of the issue.-->

### Please ensure Checkmark the following :

- [x] - Tested Localy
- [x] - Checked in IE11 and Firefox
- [ ] - Checked in mobile
- [x] - Backend work
- [ ] - Frontend work
- [x] - Bug Fixes
